### PR TITLE
fix: remove is_singular

### DIFF
--- a/admin/class-bln-publisher-admin.php
+++ b/admin/class-bln-publisher-admin.php
@@ -185,7 +185,7 @@ class BLN_Publisher_Admin
      */
     function add_user_lnp_address( $methods )
     {
-        $methods['_lnp_ln_address'] = __('Ligtning Address', 'lnp-alby');
+        $methods['_lnp_ln_address'] = __('Lightning Address', 'lnp-alby');
         return $methods;
     }
     

--- a/admin/settings/class-connections.php
+++ b/admin/settings/class-connections.php
@@ -222,10 +222,10 @@ class LNP_ConnectionPage extends LNP_SettingsPage
             '<div>
                 <table class="form-table" role="presentation"><tbody>
                     <tr>
-                        <th scope="row">%s</th><td><input type="email" class="regular-text" id="alby_email" value="" placeholder="" autocomplete="off"></td>
+                        <th scope="row">%s</th><td><input type="email" class="regular-text" id="alby_email" name="lnp_connection[alby_email]" value="" placeholder="" autocomplete="username"></td>
                     </tr>
                     <tr>
-                        <th scope="row">%s</th><td><input type="password" class="regular-text" id="alby_password" value="" placeholder="" autocomplete="off"></td>
+                        <th scope="row">%s</th><td><input type="password" class="regular-text" id="alby_password" name="lnp_connection[alby_password]" value="" placeholder="" autocomplete="new-password"></td>
                     </tr>
                     <tr>
                         <th scope="row"></th><td>

--- a/includes/class-bln-publisher-paywall.php
+++ b/includes/class-bln-publisher-paywall.php
@@ -46,6 +46,14 @@ class BLN_Publisher_Paywall
     protected $post_id;
 
     /**
+     * Length of the content.
+     *
+     * @since  1.0.0
+     * @access protected
+     * @var    int    $content_length    Length of the content.
+     */
+    protected $content_length;
+    /**
      * Full content that the Paywall is blocking.
      *
      * @since  1.0.0

--- a/includes/class-bln-publisher.php
+++ b/includes/class-bln-publisher.php
@@ -292,24 +292,6 @@ class BLN_Publisher
 
         if (!$this->lightningClient)
         {
-            // Default to post author LNaddress
-            // if specified in user profile
-            if ( is_singular( array('post') ) )
-            {
-                global $post;
-                $address = get_user_meta( $post->post_author, '_lnp_ln_address', true );
-
-                if ( $address )
-                {
-                    $this->connection_options['lnaddress_address'] = $address;
-                    
-                    $this->lightningClientType = 'lnaddress';
-                    $this->lightningClient     = new BLN_Publisher_LNAddress_Client($this->connection_options);
-                    
-                    return; 
-                }
-            }
-
             try
             {
                 if (!empty($this->connection_options['lnd_address']))
@@ -473,8 +455,22 @@ class BLN_Publisher
     /**
      * Get the lightning client
      */
-    public function getLightningClient()
+    public function getLightningClient($post_id = null)
     {
+        // Default to post author LNaddress
+        // if specified in user profile
+        if ( $post_id )
+        {
+            $post = get_post($post_id);
+            $address = get_user_meta( $post->post_author, '_lnp_ln_address', true );
+            if ( $address )
+            {
+              $connection_options = $this->connection_options;
+              $connection_options['lnaddress_address'] = $address;
+
+              return new BLN_Publisher_LNAddress_Client($connection_options);
+            }
+        }
         return $this->lightningClient;
     }
 

--- a/includes/rest-api/class-rest-server.php
+++ b/includes/rest-api/class-rest-server.php
@@ -16,6 +16,12 @@ class LNP_RESTServer
      */
     protected static $instance = null;
 
+    /**
+     * Main Plugin.
+     *
+     * @var BLN_Publisher
+     */
+    protected $plugin;
 
     /**
      * Constructor

--- a/includes/rest-api/controllers/class-rest-donations.php
+++ b/includes/rest-api/controllers/class-rest-donations.php
@@ -130,8 +130,9 @@ class LNP_DonationsController extends \WP_REST_Controller
         // if ew do not have a preimage we must check with the LN node if the invoice was paid.
         else
         {
+            $post_id    = $jwt->{'post_id'};
             $invoice_id = $jwt->{'invoice_id'};
-            $invoice    = $plugin->getLightningClient()->getInvoice($invoice_id);
+            $invoice    = $plugin->getLightningClient($post_id)->getInvoice($invoice_id);
             $settled    = $invoice['settled'];
         }
 
@@ -179,7 +180,7 @@ class LNP_DonationsController extends \WP_REST_Controller
         );
 
         $plugin  = $this->get_plugin();
-        $invoice = $plugin->getLightningClient()->addInvoice($invoice_params);
+        $invoice = $plugin->getLightningClient($post_id)->addInvoice($invoice_params);
         $plugin->getDatabaseHandler()->store_invoice(
             [
             "post_id" => $post_id,

--- a/includes/rest-api/controllers/class-rest-invoices.php
+++ b/includes/rest-api/controllers/class-rest-invoices.php
@@ -89,7 +89,7 @@ class LNP_InvoicesController extends \WP_REST_Controller
             'expiry' => 1800,
             'private' => true
         ];
-        $invoice = $plugin->getLightningClient()->addInvoice($invoice_params);
+        $invoice = $plugin->getLightningClient($post_id)->addInvoice($invoice_params);
 
         $plugin->getDatabaseHandler()->store_invoice(
             [
@@ -145,8 +145,9 @@ class LNP_InvoicesController extends \WP_REST_Controller
             $invoice = ['settled' => true];
             // if ew do not have a preimage we must check with the LN node if the invoice was paid.
         } else {
+            $post_id = $jwt->{'post_id'};
             $invoice_id = $jwt->{'invoice_id'};
-            $invoice = $plugin->getLightningClient()->getInvoice($invoice_id);
+            $invoice = $plugin->getLightningClient($post_id)->getInvoice($invoice_id);
         }
 
         // TODO check amount?

--- a/includes/rest-api/controllers/class-rest-lnurlp.php
+++ b/includes/rest-api/controllers/class-rest-lnurlp.php
@@ -100,7 +100,8 @@ class LNP_LnurlpController extends \WP_REST_Controller
         $unhashed_description = $this->get_lnurlp_metadata($payerData);
         $description_hash = hash('sha256', $unhashed_description, false);
 
-        $invoice = $this->plugin->getLightningClient()->addInvoice(
+        $post_id = intval($request->get_param('post_id'));
+        $invoice = $this->plugin->getLightningClient($post_id)->addInvoice(
             [
             'memo' => $memo, // not supported when setting a description hash
             'description_hash' => $description_hash,

--- a/includes/rest-api/controllers/class-rest-paywall.php
+++ b/includes/rest-api/controllers/class-rest-paywall.php
@@ -91,7 +91,7 @@ class LNP_PaywallController extends \WP_REST_Controller
             'expiry' => 1800,
             'private' => true
         ];
-        $invoice = $plugin->getLightningClient()->addInvoice($invoice_params);
+        $invoice = $plugin->getLightningClient($post_id)->addInvoice($invoice_params);
         $plugin->getDatabaseHandler()->store_invoice(
             [
             "post_id" => $post_id,
@@ -142,8 +142,9 @@ class LNP_PaywallController extends \WP_REST_Controller
             $invoice = ['settled' => true, 'amount' => $jwt->{"amount"}];
             // if we do not have a preimage we must check with the LN node if the invoice was paid.
         } else {
+            $post_id = $jwt->{'post_id'};
             $invoice_id = $jwt->{'invoice_id'};
-            $invoice = $plugin->getLightningClient()->getInvoice($invoice_id);
+            $invoice = $plugin->getLightningClient($post_id)->getInvoice($invoice_id);
         }
 
         // TODO check amount?

--- a/public/class-bln-publisher-public.php
+++ b/public/class-bln-publisher-public.php
@@ -135,12 +135,12 @@ class BLN_Publisher_Public
             : $options['lnurl_meta_tag_lnurlp']; // Custom option
 
 
+        $post_id = get_the_ID();
         // In case of WP_Post use authors lightning address
-        if ( is_singular( array('post') ) )
+        if ( $post_id )
         {
-            global $post;
+            $post = get_post($post_id);
             $address = get_user_meta( $post->post_author, '_lnp_ln_address', true );
-
             if ( $address )
             {
                 $lnurl = $address;


### PR DESCRIPTION
Passes `$post_id` to `getLightningClient` to avoid the use of `is_singular`